### PR TITLE
Fix attribute reads into a large buffer to not read random memory. (#…

### DIFF
--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -365,33 +365,46 @@ static uint8_t * singletonAttributeLocation(EmberAfAttributeMetadata * am)
 // This function does mem copy, but smartly, which means that if the type is a
 // string, it will copy as much as it can.
 // If src == NULL, then this method will set memory to zeroes
+// See documentation for emAfReadOrWriteAttribute for the semantics of
+// readLength when reading and writing.
 static EmberAfStatus typeSensitiveMemCopy(uint8_t * dest, uint8_t * src, EmberAfAttributeMetadata * am, bool write,
                                           uint16_t readLength)
 {
     EmberAfAttributeType attributeType = am->attributeType;
-    uint16_t size                      = (readLength == 0) ? am->size : readLength;
+    // readLength == 0 for a read indicates that we should just trust that the
+    // caller has enough space for an attribute...
+    bool ignoreReadLength = write || (readLength == 0);
+    uint16_t bufferSize   = ignoreReadLength ? am->size : readLength;
 
     if (emberAfIsStringAttributeType(attributeType))
     {
-        emberAfCopyString(dest, src, static_cast<uint8_t>(size - 1));
+        if (bufferSize < 1)
+        {
+            return EMBER_ZCL_STATUS_INSUFFICIENT_SPACE;
+        }
+        emberAfCopyString(dest, src, static_cast<uint8_t>(bufferSize - 1));
     }
     else if (emberAfIsLongStringAttributeType(attributeType))
     {
-        emberAfCopyLongString(dest, src, static_cast<uint16_t>(size - 2));
+        if (bufferSize < 2)
+        {
+            return EMBER_ZCL_STATUS_INSUFFICIENT_SPACE;
+        }
+        emberAfCopyLongString(dest, src, static_cast<uint16_t>(bufferSize - 2));
     }
     else
     {
-        if (!write && readLength != 0 && readLength < am->size)
+        if (!ignoreReadLength && readLength < am->size)
         {
             return EMBER_ZCL_STATUS_INSUFFICIENT_SPACE;
         }
         if (src == NULL)
         {
-            memset(dest, 0, size);
+            memset(dest, 0, am->size);
         }
         else
         {
-            memmove(dest, src, size);
+            memmove(dest, src, am->size);
         }
     }
     return EMBER_ZCL_STATUS_SUCCESS;


### PR DESCRIPTION
…4382)

When reading an attribute value into a large buffer, we would read the
number of bytes that can fit in the buffer, not the number of bytes
the attribute value actually takes up.  This would cause us to read
whatever memory came after the attribute value.

Also fixes some issues in typeSensitiveMemCopy when trying to
read a string-valued attribute into a buffer that's not even big
enough to fit the length value of the string.

Fixes https://github.com/project-chip/connectedhomeip/issues/4371

<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
 <<<<<FILL ME IN - the issue this PR is intended to address>>>>>

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
 <<<<<FILL ME IN - what's in this PR>>>>>

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #<<<<<FILL ME IN  - issue number(s). If no issue, please create one>>>>>

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
