### PR TITLE
HACK: Add artifacts creation to android github workflow.

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -37,6 +37,7 @@ jobs:
             image: connectedhomeip/chip-build-android:latest
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
+                - "/tmp/output_binaries:/tmp/output_binaries"
 
         steps:
             - name: Checkout
@@ -53,3 +54,27 @@ jobs:
                   yes | "$ANDROID_HOME"/tools/bin/sdkmanager --licenses
                   cd src/android/CHIPTool
                   ./gradlew build
+            - name: Binary artifact suffix
+              id: outsuffix
+              uses: haya14busa/action-cond@v1.0.0
+              with:
+                  cond: ${{ github.event.pull_request.number == '' }}
+                  if_true: "${{ github.sha }}"
+                  if_false: "pull-${{ github.event.pull_request.number }}"
+            - name: Copy aside build products
+              run: |
+                  mkdir -p /tmp/output_binaries/
+                  cp src/android/CHIPTool/app/build/outputs/apk/debug/app-debug.apk /tmp/output_binaries/
+                  cp src/android/CHIPTool/app/build/outputs/apk/release/app-release-unsigned.apk /tmp/output_binaries/app-release.apk
+            - name: Uploading Debug binary
+              uses: actions/upload-artifact@v1
+              with:
+                  name:
+                      chiptool-debug-${{ env.BUILD_TYPE }}-${{ steps.outsuffix.outputs.value }}.apk
+                  path: /tmp/output_binaries/app-debug.apk
+            - name: Uploading Release binary
+              uses: actions/upload-artifact@v1
+              with:
+                  name:
+                      chiptool-release-${{ env.BUILD_TYPE }}-${{ steps.outsuffix.outputs.value }}.apk
+                  path: /tmp/output_binaries/app-release.apk


### PR DESCRIPTION
Currently github workflow for testing chip-tools android app
doesn't preserve created binaries.

By adding possibility to upload chip-tool binaries as workflow
artifacts, developers don't have to set up whole android dev environment
locally which could be quite helpfull.

Still, it's not clear if that 'feature' will be desired by CHIP
mainteiners - that's why this commit has been marked as 'HACK'

<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Android github workflow doesn't upload binaries.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Add uploading binaries to github workflow.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #112

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
